### PR TITLE
Testability for puzzle solutions

### DIFF
--- a/aocpy/generate.py
+++ b/aocpy/generate.py
@@ -17,6 +17,9 @@ def generate_day(day: int, puzzle_input: Iterable[str]):
 
     copyfile(join(dirname(__file__), "templates/solution.py"), solution_fname)
 
+    test_fname = join(solution_dirname, f"test_day{solution_dirname}.py")
+    copyfile(join(dirname(__file__), "templates/test_solution.py"), test_fname)
+
     puzzle_input_fname = join(solution_dirname, "input.txt")
     with open(puzzle_input_fname, "w") as f:
         f.write(puzzle_input)

--- a/aocpy/templates/solution.py
+++ b/aocpy/templates/solution.py
@@ -1,15 +1,14 @@
-def part_1():
+def part_1(data):
     pass
 
 
-def part_2():
+def part_2(data):
     pass
-
 
 def main(puzzle_input_f):
     lines = [l.strip() for l in puzzle_input_f.readlines() if l]
-    print("Part 1: ", part_1())
-    print("Part 2: ", part_2())
+    print("Part 1: ", part_1(lines))
+    print("Part 2: ", part_2(lines))
 
 
 if __name__ == "__main__":

--- a/aocpy/templates/test_solution.py
+++ b/aocpy/templates/test_solution.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+import pytest
+import solution
+
+@pytest.mark.parametrize('data,expect',
+    [('sample_input_1', 'sample_output_1'),
+     ('sample_input_2', 'sample_output_2')]
+)
+def test_part1(data, expect):
+    assert solution.part_1(data) == expect
+
+@pytest.mark.parametrize('data,expect', 
+    [('sample_input_1', 'sample_output_1'),
+     ('sample_input_2', 'sample_output_2')]
+)
+def test_part2(data, expect)
+    assert solution.part_2(data) == expect
+

--- a/aocpy/templates/test_solution.py
+++ b/aocpy/templates/test_solution.py
@@ -6,13 +6,13 @@ import solution
     [('sample_input_1', 'sample_output_1'),
      ('sample_input_2', 'sample_output_2')]
 )
-def test_part1(data, expect):
+def test_part_1(data, expect):
     assert solution.part_1(data) == expect
 
 @pytest.mark.parametrize('data,expect', 
     [('sample_input_1', 'sample_output_1'),
      ('sample_input_2', 'sample_output_2')]
 )
-def test_part2(data, expect)
+def test_part_2(data, expect)
     assert solution.part_2(data) == expect
 


### PR DESCRIPTION
This adds a test_day{xx}.py to each day's generated folder, which contains some pytest boilerplate. There's also a consequential change to the solution template so that the tests can always pass in some test data. 

Intended use is for the user to copy the examples from the puzzle page into the paramertrized test function. It would be really nice to pull the test data in automatically, but AoC doesn't specifically mark up the examples in a way that makes them easy to differentiate from other lists on the page, and fetching that for part 2 of a puzzle would be especially interesting since its usually not going to be unlocked yet when we generate the folder.